### PR TITLE
Battle text

### DIFF
--- a/Project/Fall2020_CSC403_Project/App.config
+++ b/Project/Fall2020_CSC403_Project/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/Project/Fall2020_CSC403_Project/Fall2020_CSC403_Project.csproj
+++ b/Project/Fall2020_CSC403_Project/Fall2020_CSC403_Project.csproj
@@ -8,10 +8,11 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Fall2020_CSC403_Project</RootNamespace>
     <AssemblyName>Fall2020_CSC403_Project</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Project/Fall2020_CSC403_Project/FrmBattle.Designer.cs
+++ b/Project/Fall2020_CSC403_Project/FrmBattle.Designer.cs
@@ -4,16 +4,16 @@
     /// Required designer variable.
     /// </summary>
     private System.ComponentModel.IContainer components = null;
+    private System.EventHandler buttonClickEventHandler;
 
     /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing) {
-      if(disposing)
-      {
-        FrmBattle.BattleTextChanged -= SetBattleInfoTextBox;
-      }
+    protected override void Dispose(bool disposing)
+    {
+      //ensure old button on click events are not carried over between battles 
+      this.btnAttack.Click -= buttonClickEventHandler;
       
       if (disposing && (components != null)) {
         components.Dispose();
@@ -22,10 +22,10 @@
     }
 
     /// <summary>
-    /// Replace text in battleInfoTextBox. Indended to be triggered through 
+    /// Replace text in battleInfoTextBox
     /// </summary>
-    /// <param name="newText">string to override the currrent text displayed in battleInfoTextBox (can be empty too).</param>
-    private void SetBattleInfoTextBox(string newText)
+    /// <param name="newText">string to override the currrent text displayed in battleInfoTextBox (can be empty string too).</param>
+    protected void SetBattleInfoTextBox(string newText)
     {
       this.battleInfoTextBox.Text = newText;
     }
@@ -37,9 +37,6 @@
     /// the contents of this method with the code editor.
     /// </summary>
     private void InitializeComponent() {
-      //during initilaization, register to the text changing event in FrmBattle
-      FrmBattle.BattleTextChanged += SetBattleInfoTextBox;
-
       this.components = new System.ComponentModel.Container();
       this.btnAttack = new System.Windows.Forms.Button();
       this.lblPlayerHealthFull = new System.Windows.Forms.Label();
@@ -65,7 +62,8 @@
       this.btnAttack.TabIndex = 2;
       this.btnAttack.Text = "Attack";
       this.btnAttack.UseVisualStyleBackColor = true;
-      this.btnAttack.Click += new System.EventHandler(this.btnAttack_Click);
+      buttonClickEventHandler = new System.EventHandler(this.btnAttack_Click);
+      this.btnAttack.Click += buttonClickEventHandler;
       // 
       // lblPlayerHealthFull
       // 

--- a/Project/Fall2020_CSC403_Project/FrmBattle.Designer.cs
+++ b/Project/Fall2020_CSC403_Project/FrmBattle.Designer.cs
@@ -10,10 +10,24 @@
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing) {
+      if(disposing)
+      {
+        FrmBattle.BattleTextChanged -= SetBattleInfoTextBox;
+      }
+      
       if (disposing && (components != null)) {
         components.Dispose();
       }
       base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Replace text in battleInfoTextBox. Indended to be triggered through 
+    /// </summary>
+    /// <param name="newText">string to override the currrent text displayed in battleInfoTextBox (can be empty too).</param>
+    private void SetBattleInfoTextBox(string newText)
+    {
+      this.battleInfoTextBox.Text = newText;
     }
 
     #region Windows Form Designer generated code
@@ -23,6 +37,9 @@
     /// the contents of this method with the code editor.
     /// </summary>
     private void InitializeComponent() {
+      //during initilaization, register to the text changing event in FrmBattle
+      FrmBattle.BattleTextChanged += SetBattleInfoTextBox;
+
       this.components = new System.ComponentModel.Container();
       this.btnAttack = new System.Windows.Forms.Button();
       this.lblPlayerHealthFull = new System.Windows.Forms.Label();
@@ -33,6 +50,7 @@
       this.picEnemy = new System.Windows.Forms.PictureBox();
       this.picPlayer = new System.Windows.Forms.PictureBox();
       this.tmrFinalBattle = new System.Windows.Forms.Timer(this.components);
+      this.battleInfoTextBox = new System.Windows.Forms.TextBox();
       ((System.ComponentModel.ISupportInitialize)(this.picBossBattle)).BeginInit();
       ((System.ComponentModel.ISupportInitialize)(this.picEnemy)).BeginInit();
       ((System.ComponentModel.ISupportInitialize)(this.picPlayer)).BeginInit();
@@ -127,6 +145,17 @@
       this.tmrFinalBattle.Interval = 5600;
       this.tmrFinalBattle.Tick += new System.EventHandler(this.tmrFinalBattle_Tick);
       // 
+      // battleInfoTextBox
+      // 
+      this.battleInfoTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.battleInfoTextBox.Location = new System.Drawing.Point(128, 500);
+      this.battleInfoTextBox.Name = "battleInfoTextBox";
+      this.battleInfoTextBox.Size = new System.Drawing.Size(512, 80);
+      this.battleInfoTextBox.Multiline = true;
+      this.battleInfoTextBox.TabIndex = 2;
+      this.battleInfoTextBox.Text = "";
+      this.battleInfoTextBox.Enabled = false;
+      // 
       // FrmBattle
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -142,6 +171,7 @@
       this.Controls.Add(this.btnAttack);
       this.Controls.Add(this.picEnemy);
       this.Controls.Add(this.picPlayer);
+      this.Controls.Add(this.battleInfoTextBox);
       this.DoubleBuffered = true;
       this.Name = "FrmBattle";
       this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -150,7 +180,6 @@
       ((System.ComponentModel.ISupportInitialize)(this.picEnemy)).EndInit();
       ((System.ComponentModel.ISupportInitialize)(this.picPlayer)).EndInit();
       this.ResumeLayout(false);
-
     }
 
     #endregion
@@ -164,5 +193,7 @@
     private System.Windows.Forms.Label lblEnemyHealthFull;
     private System.Windows.Forms.PictureBox picBossBattle;
     private System.Windows.Forms.Timer tmrFinalBattle;
+    //battle info includes stating an atttack is being used, indicating the battle ended, etc.
+    private System.Windows.Forms.TextBox battleInfoTextBox;
   }
 }

--- a/Project/Fall2020_CSC403_Project/FrmBattle.cs
+++ b/Project/Fall2020_CSC403_Project/FrmBattle.cs
@@ -116,7 +116,8 @@ namespace Fall2020_CSC403_Project {
     //text used upon damage beign dealt after attack is used
     private string DamageTakenText(bool playerDamaged, int damageAmount)
     {
-      return (playerDamaged ? player.CharacterName : enemy.CharacterName) + " lost " + damageAmount + " health points.";
+      //damage amount will always be a negative amount, but should be worded as a positive
+      return (playerDamaged ? player.CharacterName : enemy.CharacterName) + " lost " + (-1 * damageAmount) + " health points.";
     }
 
     //while processing the damage for the enemy/player to take, display text for the attack being used and then the damage dealt

--- a/Project/Fall2020_CSC403_Project/FrmBattle.cs
+++ b/Project/Fall2020_CSC403_Project/FrmBattle.cs
@@ -11,6 +11,9 @@ namespace Fall2020_CSC403_Project {
     private Enemy enemy;
     private Player player;
 
+    public delegate void TriggerBattleTextChange(string newText);
+    public static event TriggerBattleTextChange BattleTextChanged;
+
     private FrmBattle() {
       InitializeComponent();
       player = Game.player;
@@ -64,6 +67,7 @@ namespace Fall2020_CSC403_Project {
     }
 
     private void btnAttack_Click(object sender, EventArgs e) {
+      BattleTextChanged?.Invoke("testing");
       player.OnAttack(-4);
       if (enemy.Health > 0) {
         enemy.OnAttack(-2);

--- a/Project/Fall2020_CSC403_Project/FrmBattle.cs
+++ b/Project/Fall2020_CSC403_Project/FrmBattle.cs
@@ -4,15 +4,14 @@ using System;
 using System.Drawing;
 using System.Media;
 using System.Windows.Forms;
+using System.Threading.Tasks;
 
 namespace Fall2020_CSC403_Project {
   public partial class FrmBattle : Form {
+    private static int baseMillisecondDelay = 1200;
     public static FrmBattle instance = null;
     private Enemy enemy;
     private Player player;
-
-    public delegate void TriggerBattleTextChange(string newText);
-    public static event TriggerBattleTextChange BattleTextChanged;
 
     private FrmBattle() {
       InitializeComponent();
@@ -66,31 +65,91 @@ namespace Fall2020_CSC403_Project {
       lblEnemyHealthFull.Text = enemy.Health.ToString();
     }
 
-    private void btnAttack_Click(object sender, EventArgs e) {
-      BattleTextChanged?.Invoke("testing");
-      player.OnAttack(-4);
-      if (enemy.Health > 0) {
-        enemy.OnAttack(-2);
-      }
-
-      UpdateHealthBars();
-      if (player.Health <= 0 || enemy.Health <= 0) {
-        instance = null;
-        Close();
+    private void btnAttack_Click(object sender, EventArgs e)
+    {
+      //disable the button until processing is complete. Anything other than a button as sender is invalid
+      if(sender is Button)
+      {
+        var button = (Button)sender;
+        button.Enabled = false;
+        
+        //the attack events will handle the changing of the health, GUI, and displaying text about the attack
+        player.OnAttack(-4);
+        if (enemy.Health > 0)
+        {
+          enemy.OnAttack(-2);
+          //player is defeated
+          if (player.Health <= 0)
+          {
+            BattleEndSequence(false);
+          }
+        }
+        //enemy is defeated
+        else
+        {
+          BattleEndSequence(true);
+        }
+        button.Enabled = true;
       }
     }
 
+    //display text in box for a specified amount of time before removing it
+    private void TriggerTimedTextBoxUpdate(string text, int millisecondsDelay)
+    {
+      SetBattleInfoTextBox(text);
+      TriggerBattleTimeDelay(millisecondsDelay);
+      SetBattleInfoTextBox("");
+    }
+
+    private void TriggerBattleTimeDelay(int milliseconds)
+    {
+      Task.Delay(milliseconds).Wait();
+    }
+
+    //text used when initiating an attack
+    private string AttackUsedText(bool playerAttacking)
+    {
+      return (playerAttacking ? player.CharacterName : enemy.CharacterName) + " used the " 
+                + (playerAttacking ? player.AttackName : enemy.AttackName) + " attack!";
+    }
+
+    //text used upon damage beign dealt after attack is used
+    private string DamageTakenText(bool playerDamaged, int damageAmount)
+    {
+      return (playerDamaged ? player.CharacterName : enemy.CharacterName) + " lost " + damageAmount + " health points.";
+    }
+
+    //while processing the damage for the enemy/player to take, display text for the attack being used and then the damage dealt
+    //with appropriate delays to allow the user to read the text before it proceeds
     private void EnemyDamage(int amount) {
+      TriggerTimedTextBoxUpdate(AttackUsedText(true), baseMillisecondDelay);
       enemy.AlterHealth(amount);
+      UpdateHealthBars();
+      TriggerTimedTextBoxUpdate(DamageTakenText(false, amount), baseMillisecondDelay);
     }
 
     private void PlayerDamage(int amount) {
+      TriggerTimedTextBoxUpdate(AttackUsedText(false), baseMillisecondDelay);
       player.AlterHealth(amount);
+      UpdateHealthBars();
+      TriggerTimedTextBoxUpdate(DamageTakenText(true, amount), baseMillisecondDelay);
     }
 
     private void tmrFinalBattle_Tick(object sender, EventArgs e) {
       picBossBattle.Visible = false;
       tmrFinalBattle.Enabled = false;
+    }
+
+    //hanlde processing for the battle ending to trigger appropriate event based on winner and close out of battle properly
+    private void BattleEndSequence(bool playerWon)
+    {
+      //events need to be removed at end. Else EVERY instance of player and enemy made will acculumalte across battles
+      enemy.AttackEvent -= PlayerDamage;
+      player.AttackEvent -= EnemyDamage;
+
+      TriggerTimedTextBoxUpdate((playerWon ? player.CharacterName : enemy.CharacterName) + " won the battle.", baseMillisecondDelay);
+      instance = null;
+      Close();
     }
   }
 }

--- a/Project/Fall2020_CSC403_Project/FrmLevel.cs
+++ b/Project/Fall2020_CSC403_Project/FrmLevel.cs
@@ -23,10 +23,10 @@ namespace Fall2020_CSC403_Project {
       const int PADDING = 7;
       const int NUM_WALLS = 13;
 
-      player = new Player(CreatePosition(picPlayer), CreateCollider(picPlayer, PADDING));
-      bossKoolaid = new Enemy(CreatePosition(picBossKoolAid), CreateCollider(picBossKoolAid, PADDING));
-      enemyPoisonPacket = new Enemy(CreatePosition(picEnemyPoisonPacket), CreateCollider(picEnemyPoisonPacket, PADDING));
-      enemyCheeto = new Enemy(CreatePosition(picEnemyCheeto), CreateCollider(picEnemyCheeto, PADDING));
+      player = new Player(CreatePosition(picPlayer), CreateCollider(picPlayer, PADDING), "Mr. Peanut", "Nutty Whack");
+      bossKoolaid = new Enemy(CreatePosition(picBossKoolAid), CreateCollider(picBossKoolAid, PADDING), "THE KOOLAID MAN", "OH YEAH POW");
+      enemyPoisonPacket = new Enemy(CreatePosition(picEnemyPoisonPacket), CreateCollider(picEnemyPoisonPacket, PADDING), "Poison Man", "Corosive Strike");
+      enemyCheeto = new Enemy(CreatePosition(picEnemyCheeto), CreateCollider(picEnemyCheeto, PADDING), "Chester Cheeto", "Gouda Oofa");
 
       bossKoolaid.Img = picBossKoolAid.BackgroundImage;
       enemyPoisonPacket.Img = picEnemyPoisonPacket.BackgroundImage;

--- a/Project/Fall2020_CSC403_Project/Properties/Settings.Designer.cs
+++ b/Project/Fall2020_CSC403_Project/Properties/Settings.Designer.cs
@@ -9,18 +9,18 @@
 //------------------------------------------------------------------------------
 
 namespace Fall2020_CSC403_Project.Properties {
-
-
-  [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-  [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-  internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-
-    private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-    public static Settings Default {
-      get {
-        return defaultInstance;
-      }
+    
+    
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
+        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+        
+        public static Settings Default {
+            get {
+                return defaultInstance;
+            }
+        }
     }
-  }
 }

--- a/Project/MyGameLibrary/BattleCharacter.cs
+++ b/Project/MyGameLibrary/BattleCharacter.cs
@@ -11,13 +11,19 @@ namespace Fall2020_CSC403_Project.code {
     public int Health { get; private set; }
     public int MaxHealth { get; private set; }
     private float strength;
+    private string characterName;
+    public string CharacterName { get => characterName; }
+    private string attackName;
+    public string AttackName{get => attackName; }
 
     public event Action<int> AttackEvent;
 
-    public BattleCharacter(Vector2 initPos, Collider collider) : base(initPos, collider) {
+    public BattleCharacter(Vector2 initPos, Collider collider, string charName, string charAttackName) : base(initPos, collider) {
       MaxHealth = 20;
       strength = 2;
       Health = MaxHealth;
+      characterName = charName;
+      attackName = charAttackName;
     }
 
     public void OnAttack(int amount) {

--- a/Project/MyGameLibrary/Enemy.cs
+++ b/Project/MyGameLibrary/Enemy.cs
@@ -20,7 +20,9 @@ namespace Fall2020_CSC403_Project.code {
     /// </summary>
     /// <param name="initPos">this is the initial position of the enemy</param>
     /// <param name="collider">this is the collider for the enemy</param>
-    public Enemy(Vector2 initPos, Collider collider) : base(initPos, collider) {
+    /// <param name="charName">the name of this character</param>
+    /// <param name="charAttackName">each char has one move, this is its name</param>
+    public Enemy(Vector2 initPos, Collider collider, string charName, string charAttackName) : base(initPos, collider, charName, charAttackName) {
     }
   }
 }

--- a/Project/MyGameLibrary/MyGameLibrary.csproj
+++ b/Project/MyGameLibrary/MyGameLibrary.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MyGameLibrary</RootNamespace>
     <AssemblyName>MyGameLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Project/MyGameLibrary/Player.cs
+++ b/Project/MyGameLibrary/Player.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace Fall2020_CSC403_Project.code {
   public class Player : BattleCharacter {
-    public Player(Vector2 initPos, Collider collider) : base(initPos, collider) {
+    public Player(Vector2 initPos, Collider collider, string charName, string charAttackName) : base(initPos, collider, charName, charAttackName)
+    {
 
     }
   }


### PR DESCRIPTION
This code displays a textbox in battles at the bottom. When the attack button is clicked, text is displayed in the box and async delays are used in order to give the player time to read the box before it progresses. 
This branch also fixes some observer pattern issues in the original code with battles, where the enemy and player at the start of a battle would be attached to an OnAttack event but never removed, causing the player and enemy to be duplicated and persist between battles (i.e.: after ending the first battle and entering the second, using an attack will cause the player to move twice. If a third battle is entered, the player moves three times, etc.)